### PR TITLE
Prepare initial release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 
+sudo: false
+
 # Force-enable Go modules, it will be unnecessary on Go 1.13+
 env:
   - GO111MODULE=on

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - GO111MODULE=on
 
 go:
+  - 1.11.x
   - 1.12.x
 
 # Only clone the most recent commit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# zimt Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1] - 2019-08-08 (Initial release): https://github.com/radiohive/zimt/releases/tag/v0.0.1
+### Added
+- Implement `zimt broker` command
+- Implement `zimt version` command
+- Implement `zimt bridge` command
+- Implement `zimt device list` command
+- Implement `zimt config` command

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ setup-ci:
 	@go get -u golang.org/x/lint/golint
 
 dist:
+	@ rm -rf ./dist
 	@- $(foreach p,$(PLATFORMS), \
 		build/scripts/dist.sh $(p); \
 	)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ TEST_PKGS=$(shell go list ./pkg/... 2> /dev/null)
 PLATFORMS := \
 	linux/386 \
 	linux/amd64 \
-	darwin/386 \
 	darwin/amd64
 
 build: tidy

--- a/README.md
+++ b/README.md
@@ -39,7 +39,47 @@ mqtt:
 
 ## Usage
 
-    @TODO
+`zimt` is a CLI tool to manage your zigbee connected devices via [zigbee2mqtt bridge](https://github.com/Koenkk/zigbee2mqtt).
+
+### Synopsis
+
+    zimt [flags] <command> <subcommand> [parameters]
+
+### Flags
+
+    --help
+
+Print help information
+
+    --verbose
+
+Turn on verbose/debug logging
+
+    --config /path/to/config/file
+
+Take configuration file from not default location
+
+### Commands
+
+    zimt bridge
+
+Prints bridge version
+
+    zimt broker
+
+Prints broker details
+
+    zimt config
+
+Prints zimt configuration
+
+    zimt device list
+
+Prints all connected devices
+
+    zimt version
+
+Prints zimt version and build information
 
 ## License
 

--- a/build/scripts/dist.sh
+++ b/build/scripts/dist.sh
@@ -17,9 +17,10 @@ module=$(awk '/module/{print $2}' go.mod)
 buildmeta="${module}/pkg/buildmeta"
 
 echo "Buidling ${out}..."
-GOOS=${os} GOARCH=${arch} go build -o ${out} -ldflags "\
+CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go build -o ${out} -ldflags "\
     -X '${buildmeta}.GitTag=$(git describe --abbrev=0)' \
     -X '${buildmeta}.GitCommit=$(git rev-parse --verify --short HEAD)' \
     -X '${buildmeta}.GitBranch=$(git symbolic-ref --short -q HEAD)' \
     -X '${buildmeta}.BuildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")' \
-    -X '${buildmeta}.Platform=${platform}'"
+    -X '${buildmeta}.Platform=${platform}' \
+    -extldflags '-static'"

--- a/build/scripts/dist.sh
+++ b/build/scripts/dist.sh
@@ -16,7 +16,7 @@ out="dist/zimt_${os}_${arch}"
 module=$(awk '/module/{print $2}' go.mod)
 buildmeta="${module}/pkg/buildmeta"
 
-echo "Buidling ${out}..."
+echo -ne "Buidling ${out}..."
 CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go build -o ${out} -ldflags "\
     -X '${buildmeta}.GitTag=$(git describe --abbrev=0)' \
     -X '${buildmeta}.GitCommit=$(git rev-parse --verify --short HEAD)' \
@@ -24,3 +24,9 @@ CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go build -o ${out} -ldflags "\
     -X '${buildmeta}.BuildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")' \
     -X '${buildmeta}.Platform=${platform}' \
     -extldflags '-static'"
+echo -ne " ✔\n"
+
+echo -ne "Compressing ${out}..."
+upx_out=$(upx ${out} -qq)
+echo -ne " ✔\n"
+echo "  " ${upx_out} | cut -d " " -f1-7

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,15 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	defer func() {
+		if isVerbose {
+			return
+		}
+		if err := recover(); err != nil {
+			fmt.Println(err)
+		}
+	}()
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,7 +12,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints zimt version and build information",
 	Run: func(cmd *cobra.Command, args []string) {
-		f := "%-11v%s\n"
+		f := "%-11v%v\n"
 		fmt.Printf(f, "GitTag:", buildmeta.GitTag)
 		fmt.Printf(f, "GitCommit:", buildmeta.GitCommit)
 		fmt.Printf(f, "GitBranch:", buildmeta.GitBranch)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -17,6 +17,7 @@ func getSubscribedOnce(c mqtt.Client, t string) mqtt.Message {
 	case <-time.After(5 * time.Second):
 		panic("timeout: can't get message over 5 seconds")
 	}
+	c.Unsubscribe(t)
 	return <-resp
 }
 


### PR DESCRIPTION
What's inside:
- Introduce CHANGELOG.md
- Document `usage` section in README.md
- Build statically linked binary
- Recover from any panic whithin commands and print friendlier information while not in verbose mode
- Compress binaries with upx

Closes #13 